### PR TITLE
Make `schema` and `partition_spec` optional for TableMetadataV1

### DIFF
--- a/crates/iceberg/src/spec/table_metadata.rs
+++ b/crates/iceberg/src/spec/table_metadata.rs
@@ -708,12 +708,14 @@ pub(super) mod _serde {
         pub location: String,
         pub last_updated_ms: i64,
         pub last_column_id: i32,
-        pub schema: SchemaV1,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub schema: Option<SchemaV1>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub schemas: Option<Vec<SchemaV1>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub current_schema_id: Option<i32>,
-        pub partition_spec: Vec<PartitionField>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub partition_spec: Option<Vec<PartitionField>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub partition_specs: Option<Vec<PartitionSpec>>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -925,9 +927,11 @@ pub(super) mod _serde {
                     ))
                 })
                 .or_else(|| {
-                    Some(value.schema.try_into().map(|schema: Schema| {
-                        HashMap::from_iter(vec![(schema.schema_id(), Arc::new(schema))])
-                    }))
+                    value.schema.map(|schema| {
+                        schema.try_into().map(|schema: Schema| {
+                            HashMap::from_iter(vec![(schema.schema_id(), Arc::new(schema))])
+                        })
+                    })
                 })
                 .transpose()?
                 .unwrap_or_default();
@@ -949,10 +953,15 @@ pub(super) mod _serde {
 
             let partition_specs = match value.partition_specs {
                 Some(partition_specs) => partition_specs,
-                None => vec![PartitionSpec::builder(current_schema.clone())
-                    .with_spec_id(DEFAULT_PARTITION_SPEC_ID)
-                    .add_unbound_fields(value.partition_spec.into_iter().map(|f| f.into_unbound()))?
-                    .build()?],
+                None => match value.partition_spec {
+                    Some(partition_spec) => vec![PartitionSpec::builder(current_schema.clone())
+                        .with_spec_id(DEFAULT_PARTITION_SPEC_ID)
+                        .add_unbound_fields(partition_spec.into_iter().map(|f| f.into_unbound()))?
+                        .build()?],
+                    None => vec![PartitionSpec::builder(current_schema.clone())
+                        .with_spec_id(DEFAULT_PARTITION_SPEC_ID)
+                        .build()?],
+                },
             }
             .into_iter()
             .map(|x| (x.spec_id(), Arc::new(x)))
@@ -1112,16 +1121,17 @@ pub(super) mod _serde {
                 location: v.location,
                 last_updated_ms: v.last_updated_ms,
                 last_column_id: v.last_column_id,
-                schema: v
-                    .schemas
-                    .get(&v.current_schema_id)
-                    .ok_or(Error::new(
-                        ErrorKind::Unexpected,
-                        "current_schema_id not found in schemas",
-                    ))?
-                    .as_ref()
-                    .clone()
-                    .into(),
+                schema: Some(
+                    v.schemas
+                        .get(&v.current_schema_id)
+                        .ok_or(Error::new(
+                            ErrorKind::Unexpected,
+                            "current_schema_id not found in schemas",
+                        ))?
+                        .as_ref()
+                        .clone()
+                        .into(),
+                ),
                 schemas: Some(
                     v.schemas
                         .into_values()
@@ -1133,7 +1143,7 @@ pub(super) mod _serde {
                         .collect(),
                 ),
                 current_schema_id: Some(v.current_schema_id),
-                partition_spec: v.default_spec.fields().to_vec(),
+                partition_spec: Some(v.default_spec.fields().to_vec()),
                 partition_specs: Some(
                     v.partition_specs
                         .into_values()
@@ -2594,6 +2604,29 @@ mod tests {
         };
 
         check_table_metadata_serde(&metadata, expected);
+    }
+
+    #[test]
+    fn test_table_metadata_v1_compat() {
+        let metadata =
+            fs::read_to_string("testdata/table_metadata/TableMetadataV1Compat.json").unwrap();
+
+        // Deserialize the JSON to verify it works
+        let desered_type: TableMetadata = serde_json::from_str(&metadata)
+            .expect("Failed to deserialize TableMetadataV1Compat.json");
+
+        // Verify some key fields match
+        assert_eq!(desered_type.format_version(), FormatVersion::V1);
+        assert_eq!(
+            desered_type.uuid(),
+            Uuid::parse_str("3276010d-7b1d-488c-98d8-9025fc4fde6b").unwrap()
+        );
+        assert_eq!(
+            desered_type.location(),
+            "s3://bucket/warehouse/iceberg/glue.db/table_name"
+        );
+        assert_eq!(desered_type.last_updated_ms(), 1727773114005);
+        assert_eq!(desered_type.current_schema_id(), 0);
     }
 
     #[test]

--- a/crates/iceberg/testdata/table_metadata/TableMetadataV1Compat.json
+++ b/crates/iceberg/testdata/table_metadata/TableMetadataV1Compat.json
@@ -1,0 +1,111 @@
+{
+  "current-schema-id": 0,
+  "current-snapshot-id": 917896971991367610,
+  "default-sort-order-id": 0,
+  "default-spec-id": 0,
+  "format-version": 1,
+  "last-column-id": 4,
+  "last-partition-id": 999,
+  "last-updated-ms": 1727773114005,
+  "location": "s3://bucket/warehouse/iceberg/glue.db/table_name",
+  "metadata-log": [
+    {
+      "metadata-file": "s3://bucket/warehouse/iceberg/glue.db/table_name/metadata/00405-a3e8a93b-cc7f-430b-a731-6fa4357fb94e.metadata.json",
+      "timestamp-ms": 1727772184043
+    }
+  ],
+  "partition-specs": [
+    {
+      "fields": [],
+      "spec-id": 0
+    }
+  ],
+  "partition-statistics-files": [],
+  "properties": {
+    "owner": "spark",
+    "history.expire.max-snapshot-age-ms": "18000000",
+    "write.metadata.previous-versions-max": "20",
+    "stampisoend": "20241001085028951",
+    "write.metadata.delete-after-commit.enabled": "true",
+    "history.expire.max-ref-age-ms": "2592000000",
+    "write.distribution-mode": "range",
+    "write.merge.distribution-mode": "range",
+    "history.expire.min-snapshots-to-keep": "5"
+  },
+  "refs": {
+    "main": {
+      "snapshot-id": 917896971991367610,
+      "type": "branch"
+    }
+  },
+  "schemas": [
+    {
+      "fields": [
+        {
+          "id": 1,
+          "name": "record_id",
+          "required": false,
+          "type": "long"
+        },
+        {
+          "id": 2,
+          "name": "record_time",
+          "required": false,
+          "type": "timestamptz"
+        },
+        {
+          "id": 3,
+          "name": "id",
+          "required": false,
+          "type": "long"
+        },
+        {
+          "id": 4,
+          "name": "name",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "schema-id": 0,
+      "type": "struct"
+    }
+  ],
+  "snapshot-log": [
+    {
+      "snapshot-id": 917896971991367610,
+      "timestamp-ms": 1727766315299
+    }
+  ],
+  "snapshots": [
+    {
+      "manifest-list": "s3://bucket/warehouse/iceberg/glue.db/table_name/metadata/snap-917896971991367610-1-d466808b-46f1-4486-a655-e50d07014597.avro",
+      "schema-id": 0,
+      "snapshot-id": 917896971991367610,
+      "summary": {
+        "added-data-files": "1",
+        "total-equality-deletes": "0",
+        "added-records": "3",
+        "deleted-data-files": "1",
+        "deleted-records": "3",
+        "total-records": "3",
+        "removed-files-size": "1366",
+        "changed-partition-count": "1",
+        "total-position-deletes": "0",
+        "added-files-size": "1366",
+        "total-delete-files": "0",
+        "total-files-size": "1366",
+        "total-data-files": "1",
+        "operation": "overwrite"
+      },
+      "timestamp-ms": 1727766315299
+    }
+  ],
+  "sort-orders": [
+    {
+      "fields": [],
+      "order-id": 0
+    }
+  ],
+  "statistics-files": [],
+  "table-uuid": "3276010d-7b1d-488c-98d8-9025fc4fde6b"
+}


### PR DESCRIPTION
Upstream PR: https://github.com/apache/iceberg-rust/pull/1087

## Which issue does this PR close?

TBD

## What changes are included in this PR?

Fixes an issue reading V1 Iceberg tables created by AWS Glue. The table metadata for V1 tables in Glue don't have the `schema` or `partition-spec` fields that `TableMetadataV1` marks as required. Fix this by making these fields optional and adding a test.

## Are these changes tested?

Yes, a new test to verify that a Glue V1 Iceberg table can correctly be parsed into a TableMetadata.