### PR TITLE
Allow passing explicit AWS credentials to Rest API AWS Auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,7 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+checksum = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -670,15 +670,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-runtime"
-version = "1.5.4"
+name = "aws-lc-rs"
+version = "1.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee7643696e7fdd74c10f9eb42848a87fe469d35eae9c3323f80aa98f350baac"
+checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77926887776171ced7d662120a75998e444d3750c951abfe07f90da130514b1f"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -703,7 +726,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -725,7 +748,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -747,7 +770,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -769,7 +792,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -784,14 +807,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.54.1"
+version = "1.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861d324ef69247c6f3c6823755f408a68877ffb1a9afaff6dd8b0057c760de60"
+checksum = "065c533fbe6f84962af33fcf02b0350b7c1f79285baab5924615d2be3b232855"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -807,12 +830,12 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690118821e46967b3c4501d67d7d52dd75106a9c54cf36cefa1985cedbe94e05"
+checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.0",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -830,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa59d1327d8b5053c54bf2eaae63bf629ba9e904434d0835a28ed3c0ed0a614e"
+checksum = "1e190749ea56f8c42bf15dd76c65e14f8f765233e6df9b0506d9d934ebef867c"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -860,10 +883,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-json"
-version = "0.61.2"
+name = "aws-smithy-http"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623a51127f24c30776c8b374295f2df78d92517386f77ba30773f15a30ce1422"
+checksum = "c5949124d11e538ca21142d1fba61ab0a2a2c1bc3ed323cdb3e4b878bfb83166"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.2.0",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0497ef5d53065b7cd6a35e9c1654bd1fefeae5c52900d91d1b188b0af0f29324"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.4.7",
+ "http 0.2.12",
+ "http 1.2.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.6.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.21",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92144e45819cae7dc62af23eac5a038a58aa544432d2102609654376a900bd07"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -880,36 +952,33 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.7"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865f7050bbc7107a6c98a397a9fcd9413690c27fa718446967cf03b2d3ac517e"
+checksum = "f6328865e36c6fd970094ead6b05efd047d3a80ec5fc3be5e743910da9f2ebf8"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.0",
+ "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2 0.3.26",
  "http 0.2.12",
+ "http 1.2.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "httparse",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
+checksum = "3da37cf5d57011cb1753456518ec76e31691f1f474b73934a284eb2a1c76510f"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -924,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.12"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f6feb647fb5e0d5b50f0472c19a7db9462b74e2fec01bb0b44eedcc834e97"
+checksum = "836155caafba616c0ff9b07944324785de2ab016141c3550bd1c07882f8cee8f"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -959,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.4"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0df5a18c4f951c645300d365fec53a61418bcf4650f604f85fe2a665bfaa0c2"
+checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1044,6 +1113,29 @@ name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.7.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.96",
+ "which",
+]
 
 [[package]]
 name = "bitflags"
@@ -1215,9 +1307,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -1271,6 +1363,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1354,6 +1455,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1547,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1671,7 +1802,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.7.0",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "num_cpus",
  "object_store",
@@ -1793,7 +1924,7 @@ checksum = "4da0f3cb4669f9523b403d6b5a0ec85023e0ab3bf0183afd1517475b3e64fdd2"
 dependencies = [
  "arrow",
  "datafusion-common",
- "itertools",
+ "itertools 0.13.0",
  "paste",
 ]
 
@@ -1814,7 +1945,7 @@ dependencies = [
  "datafusion-expr",
  "hashbrown 0.14.5",
  "hex",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "md-5",
  "rand",
@@ -1876,7 +2007,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-physical-expr-common",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "paste",
  "rand",
@@ -1921,7 +2052,7 @@ dependencies = [
  "datafusion-physical-expr",
  "hashbrown 0.14.5",
  "indexmap 2.7.0",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "paste",
  "regex-syntax 0.8.5",
@@ -1949,7 +2080,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.7.0",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "paste",
  "petgraph",
@@ -1982,7 +2113,7 @@ dependencies = [
  "datafusion-expr-common",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2011,7 +2142,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.7.0",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "once_cell",
  "parking_lot",
@@ -2174,6 +2305,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -2346,6 +2483,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2810,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2840,7 +2983,7 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -2853,9 +2996,10 @@ checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.21",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -2874,7 +3018,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2932,7 +3076,7 @@ dependencies = [
  "futures",
  "iceberg-catalog-memory",
  "iceberg_test_utils",
- "itertools",
+ "itertools 0.13.0",
  "moka",
  "murmur3",
  "num-bigint",
@@ -3008,7 +3152,7 @@ dependencies = [
  "async-trait",
  "futures",
  "iceberg",
- "itertools",
+ "itertools 0.13.0",
  "regex",
  "serde_json",
  "tempfile",
@@ -3024,13 +3168,14 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
+ "aws-sdk-sts",
  "aws-sigv4",
  "chrono",
  "ctor",
  "http 1.2.0",
  "iceberg",
  "iceberg_test_utils",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "mockito",
  "port_scanner",
@@ -3055,7 +3200,7 @@ dependencies = [
  "aws-sdk-s3tables",
  "iceberg",
  "iceberg_test_utils",
- "itertools",
+ "itertools 0.13.0",
  "serde_json",
  "tokio",
  "uuid",
@@ -3068,7 +3213,7 @@ dependencies = [
  "async-trait",
  "iceberg",
  "iceberg_test_utils",
- "itertools",
+ "itertools 0.13.0",
  "regex",
  "serde_json",
  "sqlx",
@@ -3361,6 +3506,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3425,6 +3579,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical-core"
@@ -3518,6 +3678,16 @@ dependencies = [
  "core2",
  "hashbrown 0.14.5",
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3661,7 +3831,7 @@ dependencies = [
  "ahash 0.8.11",
  "faststr",
  "paste",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "tokio",
 ]
 
@@ -3670,6 +3840,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3704,7 +3880,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rand",
@@ -3803,6 +3979,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3964,7 +4150,7 @@ dependencies = [
  "chrono",
  "futures",
  "humantime",
- "itertools",
+ "itertools 0.13.0",
  "parking_lot",
  "percent-encoding",
  "snafu",
@@ -4428,6 +4614,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4521,7 +4717,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "rustls 0.23.21",
  "socket2",
  "thiserror 2.0.11",
@@ -4539,7 +4735,7 @@ dependencies = [
  "getrandom",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "rustls 0.23.21",
  "rustls-pki-types",
  "slab",
@@ -4756,7 +4952,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.5",
  "hyper-util",
  "ipnet",
@@ -4938,6 +5134,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
@@ -4985,6 +5187,7 @@ version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5002,7 +5205,19 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -5025,9 +5240,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
 ]
@@ -5048,6 +5263,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5138,7 +5354,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.7.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.7.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6420,7 +6649,7 @@ dependencies = [
  "paste",
  "pilota",
  "pin-project",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "scopeguard",
  "sonic-rs",
  "thiserror 2.0.11",
@@ -6577,6 +6806,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -6874,7 +7115,7 @@ dependencies = [
  "futures",
  "http 1.2.0",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,6 +2039,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,6 +3042,7 @@ dependencies = [
  "tokio",
  "typed-builder 0.20.0",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -6840,6 +6859,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "101681b74cd87b5899e87bcf5a64e83334dd313fcd3053ea72e6dba18928e301"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.2.0",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ async-trait = "0.1"
 async-std = "1.12"
 aws-config = "1"
 aws-sdk-glue = "1.39"
+aws-sdk-sts = "1.63"
 aws-sigv4 = { version = "1.2", features = ["sign-http"] }
 aws-credential-types = "1.2"
 bimap = "0.6"

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -35,6 +35,7 @@ async-trait = { workspace = true }
 aws-config = { workspace = true, optional = true }
 aws-sigv4 = { workspace = true, optional = true }
 aws-credential-types = { workspace = true, optional = true }
+aws-sdk-sts = { workspace = true, optional = true }
 chrono = { workspace = true }
 http = "1.1.0"
 iceberg = { workspace = true }
@@ -59,4 +60,4 @@ wiremock = "0.6"
 
 [features]
 default = ["sigv4"]
-sigv4 = ["aws-config", "aws-sigv4", "aws-credential-types"]
+sigv4 = ["aws-config", "aws-sigv4", "aws-credential-types", "aws-sdk-sts"]

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -55,6 +55,7 @@ iceberg_test_utils = { path = "../../test_utils", features = ["tests"] }
 mockito = { workspace = true }
 port_scanner = { workspace = true }
 tokio = { workspace = true }
+wiremock = "0.6"
 
 [features]
 default = ["sigv4"]

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -234,6 +234,18 @@ impl RestCatalogConfig {
     pub(crate) fn signing_name(&self) -> Option<String> {
         self.props.get("rest.signing-name").cloned()
     }
+
+    pub(crate) fn access_key_id(&self) -> Option<String> {
+        self.props.get("rest.access-key-id").cloned()
+    }
+
+    pub(crate) fn secret_access_key(&self) -> Option<String> {
+        self.props.get("rest.secret-access-key").cloned()
+    }
+
+    pub(crate) fn session_token(&self) -> Option<String> {
+        self.props.get("rest.session-token").cloned()
+    }
 }
 
 #[derive(Debug)]

--- a/crates/catalog/rest/src/catalog.rs
+++ b/crates/catalog/rest/src/catalog.rs
@@ -246,6 +246,14 @@ impl RestCatalogConfig {
     pub(crate) fn session_token(&self) -> Option<String> {
         self.props.get("rest.session-token").cloned()
     }
+
+    pub(crate) fn role_arn(&self) -> Option<String> {
+        self.props.get("rest.role-arn").cloned()
+    }
+
+    pub(crate) fn role_session_name(&self) -> Option<String> {
+        self.props.get("rest.role-session-name").cloned()
+    }
 }
 
 #[derive(Debug)]

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -62,11 +62,23 @@ impl HttpClient {
 
         #[cfg(feature = "sigv4")]
         if cfg.sigv4_enabled() {
-            client_builder = client_builder.with(crate::middleware::sigv4::SigV4Middleware::new(
+            let mut sigv4_middleware = crate::middleware::sigv4::SigV4Middleware::new(
                 &cfg.base_url(),
                 cfg.signing_name().as_deref().unwrap_or("glue"),
                 cfg.signing_region().as_deref(),
-            ));
+            );
+
+            if let (Some(access_key_id), Some(secret_access_key)) =
+                (cfg.access_key_id(), cfg.secret_access_key())
+            {
+                sigv4_middleware = sigv4_middleware.with_credentials(
+                    access_key_id,
+                    secret_access_key,
+                    cfg.session_token(),
+                );
+            }
+
+            client_builder = client_builder.with(sigv4_middleware);
         }
 
         Ok(HttpClient {

--- a/crates/catalog/rest/src/client.rs
+++ b/crates/catalog/rest/src/client.rs
@@ -78,6 +78,10 @@ impl HttpClient {
                 );
             }
 
+            if let Some(role_arn) = cfg.role_arn() {
+                sigv4_middleware = sigv4_middleware.with_role(role_arn, cfg.role_session_name());
+            }
+
             client_builder = client_builder.with(sigv4_middleware);
         }
 

--- a/crates/catalog/rest/src/middleware/sigv4.rs
+++ b/crates/catalog/rest/src/middleware/sigv4.rs
@@ -22,6 +22,7 @@ use std::time::SystemTime;
 use anyhow::anyhow;
 use aws_config::{BehaviorVersion, Region};
 use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::Credentials;
 use aws_sigv4::http_request::{sign, SignableBody, SignableRequest, SigningSettings};
 use aws_sigv4::sign::v4;
 use http::Extensions;
@@ -33,6 +34,10 @@ pub(crate) struct SigV4Middleware {
     catalog_uri: String,
     signing_name: String,
     signing_region: Option<String>,
+
+    access_key_id: Option<String>,
+    secret_access_key: Option<String>,
+    session_token: Option<String>,
     config: OnceCell<aws_config::SdkConfig>,
 }
 
@@ -42,8 +47,23 @@ impl SigV4Middleware {
             catalog_uri: catalog_uri.to_string(),
             signing_name: signing_name.to_string(),
             signing_region: signing_region.map(|s| s.to_string()),
+            access_key_id: None,
+            secret_access_key: None,
+            session_token: None,
             config: OnceCell::new(),
         }
+    }
+
+    pub(crate) fn with_credentials(
+        mut self,
+        access_key_id: String,
+        secret_access_key: String,
+        session_token: Option<String>,
+    ) -> Self {
+        self.access_key_id = Some(access_key_id);
+        self.secret_access_key = Some(secret_access_key);
+        self.session_token = session_token;
+        self
     }
 }
 
@@ -67,6 +87,17 @@ impl Middleware for SigV4Middleware {
                 let mut config_loader = aws_config::defaults(BehaviorVersion::v2024_03_28());
                 if let Some(signing_region) = signing_region {
                     config_loader = config_loader.region(Region::new(signing_region));
+                }
+                if let (Some(access_key_id), Some(secret_access_key)) =
+                    (&self.access_key_id, &self.secret_access_key)
+                {
+                    config_loader = config_loader.credentials_provider(Credentials::new(
+                        access_key_id,
+                        secret_access_key,
+                        self.session_token.clone(),
+                        None,
+                        "iceberg-rest-catalog",
+                    ));
                 }
                 config_loader.load().await
             })
@@ -125,5 +156,221 @@ impl Middleware for SigV4Middleware {
         }
 
         next.run(req, extensions).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::sync::{LazyLock, Mutex};
+
+    use reqwest::Client;
+    use reqwest_middleware::ClientBuilder;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    static TEST_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn set_test_credentials() {
+        env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+        env::set_var(
+            "AWS_SECRET_ACCESS_KEY",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        );
+    }
+
+    fn unset_test_credentials() {
+        env::remove_var("AWS_ACCESS_KEY_ID");
+        env::remove_var("AWS_SECRET_ACCESS_KEY");
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_middleware_handles_missing_credentials() {
+        let _guard = TEST_MUTEX.lock();
+
+        // Start a mock server
+        let mock_server = MockServer::start().await;
+        let catalog_uri = mock_server.uri();
+
+        // Create middleware
+        let middleware = SigV4Middleware::new(&catalog_uri, "s3", Some("us-east-1"));
+
+        // Create a client with the middleware
+        let client = ClientBuilder::new(Client::new()).with(middleware).build();
+
+        // Make request (should fail due to no credentials)
+        let resp = client.get(&catalog_uri).send().await;
+        assert!(resp.is_err());
+        match resp.unwrap_err() {
+            reqwest_middleware::Error::Middleware(_e) => {}
+            _ => panic!("Unexpected error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_middleware_signs_matching_requests() {
+        let _guard = TEST_MUTEX.lock();
+
+        // Start a mock server
+        let mock_server = MockServer::start().await;
+        let catalog_uri = mock_server.uri();
+
+        // Create middleware with test credentials
+        set_test_credentials();
+        let middleware = SigV4Middleware::new(&catalog_uri, "s3", Some("us-east-1"));
+
+        // Create a client with the middleware
+        let client = ClientBuilder::new(Client::new()).with(middleware).build();
+
+        // Set up mock to check for AWS auth header
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(HeaderStartsWith("Authorization", "AWS4-HMAC-SHA256"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // Make request
+        let resp = client.get(&catalog_uri).send().await;
+        assert!(resp.is_ok());
+
+        // Verify all mocks were called as expected
+        mock_server.verify().await;
+        unset_test_credentials();
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_middleware_skips_non_matching_requests() {
+        let _guard = TEST_MUTEX.lock();
+
+        // Start a mock server
+        let mock_server = MockServer::start().await;
+
+        // Create middleware with different URI and test credentials
+        set_test_credentials();
+        let middleware = SigV4Middleware::new("http://different-uri", "s3", Some("us-east-1"));
+
+        // Create a client with the middleware
+        let client = ClientBuilder::new(Client::new()).with(middleware).build();
+
+        // Set up mock that expects no AWS auth header
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(HeaderMissing("Authorization"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // Make request
+        let resp = client.get(mock_server.uri()).send().await;
+        assert!(resp.is_ok());
+
+        // Verify all mocks were called as expected
+        mock_server.verify().await;
+        unset_test_credentials();
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_middleware_with_explicit_credentials() {
+        let _guard = TEST_MUTEX.lock();
+
+        // Start a mock server
+        let mock_server = MockServer::start().await;
+        let catalog_uri = mock_server.uri();
+
+        // Make sure environment credentials are not set
+        unset_test_credentials();
+
+        // Create middleware with explicit credentials
+        let middleware = SigV4Middleware::new(&catalog_uri, "s3", Some("us-east-1"))
+            .with_credentials(
+                "EXPLICIT_KEY_ID".to_string(),
+                "EXPLICIT_SECRET_KEY".to_string(),
+                Some("EXPLICIT_SESSION_TOKEN".to_string()),
+            );
+
+        // Create a client with the middleware
+        let client = ClientBuilder::new(Client::new()).with(middleware).build();
+
+        // Set up mock to check for AWS auth header
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(HeaderStartsWith("Authorization", "AWS4-HMAC-SHA256"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // Make request
+        let resp = client.get(&catalog_uri).send().await;
+        assert!(resp.is_ok());
+
+        // Verify all mocks were called as expected
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn test_sigv4_middleware_explicit_credentials_override_env() {
+        let _guard = TEST_MUTEX.lock();
+
+        // Start a mock server
+        let mock_server = MockServer::start().await;
+        let catalog_uri = mock_server.uri();
+
+        // Set environment credentials that should be ignored
+        set_test_credentials();
+
+        // Create middleware with explicit credentials that should take precedence
+        let middleware = SigV4Middleware::new(&catalog_uri, "s3", Some("us-east-1"))
+            .with_credentials(
+                "EXPLICIT_OVERRIDE_KEY".to_string(),
+                "EXPLICIT_OVERRIDE_SECRET".to_string(),
+                None,
+            );
+
+        // Create a client with the middleware
+        let client = ClientBuilder::new(Client::new()).with(middleware).build();
+
+        // Set up mock to check for AWS auth header
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(HeaderStartsWith("Authorization", "AWS4-HMAC-SHA256"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // Make request
+        let resp = client.get(&catalog_uri).send().await;
+        assert!(resp.is_ok());
+
+        // Verify all mocks were called as expected
+        mock_server.verify().await;
+        unset_test_credentials();
+    }
+
+    struct HeaderMissing(&'static str);
+
+    impl wiremock::Match for HeaderMissing {
+        fn matches(&self, request: &wiremock::Request) -> bool {
+            !request.headers.contains_key(self.0)
+        }
+    }
+
+    struct HeaderStartsWith(&'static str, &'static str);
+
+    impl wiremock::Match for HeaderStartsWith {
+        fn matches(&self, request: &wiremock::Request) -> bool {
+            request
+                .headers
+                .get(self.0)
+                .and_then(|h| h.to_str().ok())
+                .map(|v| v.starts_with(self.1))
+                .unwrap_or(false)
+        }
     }
 }


### PR DESCRIPTION
I've included this change in my pending upstream PR: https://github.com/apache/iceberg-rust/pull/917

## What changes are included in this PR?

Allow specifying explicit credentials via the `rest.access-key-id`, `rest.secret-access-key`, and `rest.session-token` properties in the `RestCatalogConfig` struct.

## Are these changes tested?

Yes