### PR TITLE
Support Dictionary types in Arrow Schema to Iceberg Schema conversion

### DIFF
--- a/crates/iceberg/src/arrow/schema.rs
+++ b/crates/iceberg/src/arrow/schema.rs
@@ -168,6 +168,7 @@ fn visit_type<V: ArrowSchemaVisitor>(r#type: &DataType, visitor: &mut V) -> Resu
             )),
         },
         DataType::Struct(fields) => visit_struct(fields, visitor),
+        DataType::Dictionary(_, value_type) => visit_type(value_type, visitor),
         other => Err(Error::new(
             ErrorKind::DataInvalid,
             format!("Cannot visit Arrow data type: {other}"),
@@ -1521,6 +1522,15 @@ mod tests {
                 .into(),
             ]));
             assert_eq!(arrow_type, type_to_arrow_type(&iceberg_type).unwrap());
+        }
+
+        // test dictionary type
+        {
+            let arrow_type =
+                DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8));
+            let iceberg_type = Type::Primitive(PrimitiveType::String);
+            assert_eq!(iceberg_type, arrow_type_to_type(&arrow_type).unwrap());
+            assert_eq!(DataType::Utf8, type_to_arrow_type(&iceberg_type).unwrap());
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/iceberg-rust/issues/1282

## What changes are included in this PR?

Adds support for converting Arrow dictionary types to the base Iceberg type

## Are these changes tested?

Yes