### PR TITLE
Relax the AWS SDK version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,12 @@ arrow-select = { version = "55" }
 arrow-string = { version = "55" }
 async-std = "1.12"
 async-trait = "0.1.88"
-aws-config = "1.6.1"
-aws-sdk-glue = "1.39"
+aws-config = "1"
+aws-credential-types = "1"
+aws-sdk-glue = "1"
+aws-sdk-sts = "1"
+aws-sigv4 = { version = "1", features = ["sign-http"] }
 base64 = "0.22.1"
-aws-sdk-sts = "1.63"
-aws-sigv4 = { version = "1.2", features = ["sign-http"] }
-aws-credential-types = "1.2"
 bimap = "0.6"
 bytes = "1.10"
 chrono = "0.4.40"


### PR DESCRIPTION
Relax the AWS SDK versions to allow library consumers to specify their AWS SDK