### PR TITLE
fix: CI check failures for spiceai-0.9.0 merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3461,7 +3461,6 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
- "aws-sdk-sts",
  "aws-sigv4",
  "chrono",
  "http 1.4.0",

--- a/crates/catalog/rest/Cargo.toml
+++ b/crates/catalog/rest/Cargo.toml
@@ -34,7 +34,6 @@ async-trait = { workspace = true }
 aws-config = { workspace = true, optional = true }
 aws-sigv4 = { workspace = true, optional = true }
 aws-credential-types = { workspace = true, optional = true }
-aws-sdk-sts = { workspace = true, optional = true }
 chrono = { workspace = true }
 http = { workspace = true }
 iceberg = { workspace = true }
@@ -56,4 +55,4 @@ tokio = { workspace = true }
 wiremock = "=0.6.4"
 [features]
 default = ["sigv4"]
-sigv4 = ["aws-config", "aws-sigv4", "aws-credential-types", "aws-sdk-sts"]
+sigv4 = ["aws-config", "aws-sigv4", "aws-credential-types"]

--- a/crates/integrations/datafusion/src/physical_plan/scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/scan.rs
@@ -190,15 +190,18 @@ impl DisplayAs for IcebergTableScan {
     ) -> std::fmt::Result {
         write!(
             f,
-            "IcebergTableScan projection:[{}] predicate:[{}] limit:[{}]",
+            "IcebergTableScan projection:[{}] predicate:[{}]",
             self.projection
                 .clone()
                 .map_or(String::new(), |v| v.join(",")),
             self.predicates
                 .clone()
                 .map_or(String::from(""), |p| format!("{p}")),
-            self.limit.map_or(String::from(""), |p| format!("{p}")),
-        )
+        )?;
+        if let Some(limit) = self.limit {
+            write!(f, " limit:[{limit}]")?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Fixes the two failing CI checks on PR #32:

- **cargo-machete**: Remove unused direct `aws-sdk-sts` dependency from `iceberg-catalog-rest` (transitively provided by `aws-config`)
- **sqllogictests**: Only display `limit:[N]` in `IcebergTableScan` when a limit is actually set, fixing `binary_predicate_pushdown` and `boolean_predicate_pushdown` EXPLAIN output mismatches